### PR TITLE
HW 11

### DIFF
--- a/hw11/contributions.txt
+++ b/hw11/contributions.txt
@@ -1,0 +1,22 @@
+Project team, HW11, SWE 619, 11/20/2018
+-------------
+Kyle Jackson,
+Nat Greenwald, and
+Stefan Soto
+
+Their contributions are as follows:
+
+Stefan Soto
+
+- contributed to discussion regarding all facets of the assignment
+
+Kyle Jackson
+
+- contributed to discussion regarding all facets of the assignment
+
+
+Nat Greenwald
+
+- contributed to discussion regarding all facets of the assignment
+
+All project members attest that each member contributed substantially and equally.

--- a/hw11/contributions.txt
+++ b/hw11/contributions.txt
@@ -7,16 +7,16 @@ Stefan Soto
 Their contributions are as follows:
 
 Stefan Soto
-
+- Implemented the Map interface portion of the assignment
 - contributed to discussion regarding all facets of the assignment
 
 Kyle Jackson
-
+- Implemented the Collection interface portion of the assignment
 - contributed to discussion regarding all facets of the assignment
 
 
 Nat Greenwald
-
+- Implemented the List interface portion of the assignment
 - contributed to discussion regarding all facets of the assignment
 
 All project members attest that each member contributed substantially and equally.

--- a/hw11/src/ForwardingSet.java
+++ b/hw11/src/ForwardingSet.java
@@ -1,0 +1,48 @@
+import java.util.Iterator;
+import java.util.Set;
+import java.util.Collection;
+
+public class ForwardingSet<E> implements Set<E> {
+    private final Set<E> s;
+    public ForwardingSet(Set<E> s) {this.s = s; }
+
+    public void clear() { s.clear(); }
+    public boolean contains(Object o) { return s.contains(o); }
+    public boolean isEmpty() { return s.isEmpty(); }
+    public int size() { return s.size(); }
+    public Iterator<E> iterator() {
+        return s.iterator();
+    }
+    public boolean add(E e) { return s.add(e); }
+    public boolean remove(Object o) { return s.remove(o); }
+    public boolean containsAll(Collection<?> c) {
+        return s.containsAll(c);
+    }
+    public boolean addAll(Collection<? extends E> c) {
+        return s.addAll(c);
+    }
+    public boolean removeAll(Collection<?> c) {
+        return s.removeAll(c);
+    }
+    public boolean retainAll(Collection<?> c) {
+        return s.retainAll(c);
+    }
+    public Object[] toArray() {
+        return s.toArray();
+    }
+    public <T> T[] toArray(T[] a) {
+        return s.toArray(a);
+    }
+    @Override
+    public boolean equals(Object o) {
+        return s.equals(o);
+    }
+    @Override
+    public int hashCode() {
+        return s.hashCode();
+    }
+    @Override
+    public String toString() {
+        return s.toString();
+    }
+}

--- a/hw11/src/InstrumentedCollection.java
+++ b/hw11/src/InstrumentedCollection.java
@@ -1,0 +1,65 @@
+import java.util.Collection;
+import java.util.Iterator;
+
+public class InstrumentedCollection<E> extends ForwardingCollection<E>  {
+    private int addCount = 0;
+
+    public InstrumentedCollection(Collection<E> c) { super(c); }
+
+    @Override public boolean add(E e) { addCount++; return super.add(e); }
+
+    @Override public boolean addAll(Collection<? extends E> c) {
+        addCount += c.size();
+        return super.addAll(c);
+    }
+
+    public int getAddCount() {
+        return addCount;
+    }
+}
+
+class ForwardingCollection<E> implements Collection<E> {
+    private final Collection<E> s;
+
+    public ForwardingCollection(Collection<E> s) {this.s = s; }
+
+    public void clear() { s.clear(); }
+    public boolean contains(Object o) { return s.contains(o); }
+    public boolean isEmpty() { return s.isEmpty(); }
+    public int size() { return s.size(); }
+    public Iterator<E> iterator() {
+        return s.iterator();
+    }
+    public boolean add(E e) { return s.add(e); }
+    public boolean remove(Object o) { return s.remove(o); }
+    public boolean containsAll(Collection<?> c) {
+        return s.containsAll(c);
+    }
+    public boolean addAll(Collection<? extends E> c) {
+        return s.addAll(c);
+    }
+    public boolean removeAll(Collection<?> c) {
+        return s.removeAll(c);
+    }
+    public boolean retainAll(Collection<?> c) {
+        return s.retainAll(c);
+    }
+    public Object[] toArray() {
+        return s.toArray();
+    }
+    public <T> T[] toArray(T[] a) {
+        return s.toArray(a);
+    }
+    @Override
+    public boolean equals(Object o) {
+        return s.equals(o);
+    }
+    @Override
+    public int hashCode() {
+        return s.hashCode();
+    }
+    @Override
+    public String toString() {
+        return s.toString();
+    }
+}

--- a/hw11/src/InstrumentedList.java
+++ b/hw11/src/InstrumentedList.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.ListIterator;
 
 
-public class InstrumentedList extends ForwardingList<E>{
+public class InstrumentedList<E> extends ForwardingList<E>{
     private int addCount = 0;
 
     public InstrumentedList(List<E> l){ super(l); }

--- a/hw11/src/InstrumentedList.java
+++ b/hw11/src/InstrumentedList.java
@@ -1,0 +1,61 @@
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
+
+public class InstrumentedList extends ForwardingList<E>{
+    private int addCount = 0;
+
+    public InstrumentedList(List<E> l){ super(l); }
+
+    @Override public boolean add(E e){
+        addCount++;
+        return super.add(e);
+    }
+
+    @Override public void add(int index, E e){
+        addCount++;
+        super.add(index, e);
+    }
+
+    @Override public boolean addAll(Collection<? extends E> c) {
+        addCount += c.size();
+        return super.addAll(c);
+    }
+
+    public int getAddCount(){ return addCount; }
+}
+
+class ForwardingList<E> implements List<E> {
+    private final List<E> l;
+
+    public ForwardingList(List<E> l)  { this.l = l; }
+    public boolean add(E e)           { return l.add(e); }
+    public void add(int index, E e)   { l.add(index, e); }
+    public boolean addAll(Collection<? extends E> c)            { return l.addAll(c); }
+    public boolean addAll(int index, Collection<? extends E> c) { return l.addAll(index, c); }
+    public void clear()               { l.clear(); }
+    public boolean contains(Object o) { return l.contains(o); }
+    public boolean containsAll(Collection<?> c)                 { return l.containsAll(c); }
+    public boolean equals(Object o)   { return l.equals(o); }
+    public E get(int index)           { return l.get(index); }
+    public int hashCode()             { return l.hashCode(); }
+    public int indexOf(Object o)      { return l.indexOf(o); }
+    public boolean isEmpty()          { return l.isEmpty(); }
+    public Iterator<E> iterator()     { return l.iterator(); }
+    public int lastIndexOf(Object o)  { return l.lastIndexOf(o); }
+    public ListIterator<E> listIterator()                       { return l.listIterator(); }
+    public ListIterator<E> listIterator(int index)              { return l.listIterator(index); }
+    public E remove(int index)        { return l.remove(index); }
+    public boolean remove(Object o)   { return l.remove(o); }
+    public boolean removeAll(Collection<?> c)                   { return l.removeAll(c); }
+    public boolean retainAll(Collection<?> c)                   { return l.retainAll(c); }
+    public E set(int index, E element)                          { return l.set(index, element); }
+    public int size()                 { return l.size(); }
+    public List<E> subList(int fromIndex, int toIndex)          { return l.subList(fromIndex, toIndex); }
+    public Object[] toArray()         { return l.toArray(); }
+    public <T> T[] toArray(T[] a)     { return l.toArray(a); }
+    public String  toString()         { return l.toString(); }
+
+}

--- a/hw11/src/InstrumentedMap.java
+++ b/hw11/src/InstrumentedMap.java
@@ -20,16 +20,16 @@ public class InstrumentedMap<K,V> extends ForwardingMap<K,V>{
 	   public int hashCode()      		{ return s.hashCode();}
 	   public String  toString()      	{ return s.toString();}
 	  
-	   public void clear() {s.clear();}
+	   public void clear()              {s.clear();}
 	   public boolean isEmpty()			{ return s.isEmpty();}
 	   public int size() 				{ return s.size();}
 
 	   public void putAll(Map<? extends K,? extends V> m) 
 	   	                               { s.putAll(m);}
-	   public boolean containsKey(Object key)	     {return s.containsKey(key);}
+	   public boolean containsKey(Object key)        {return s.containsKey(key);}
 	   public boolean containsValue(Object value)    {return s.containsValue(value);}
 	   public V get(Object key)                      {return s.get(key);}
-	   public Set<K> keySet()	                     {return s.keySet();}
+	   public Set<K> keySet()                        {return s.keySet();}
 	   public Collection<V> values()                 {return s.values();}
 	   public Set<Entry<K, V>> entrySet()            {return s.entrySet();}
 }

--- a/hw11/src/InstrumentedMap.java
+++ b/hw11/src/InstrumentedMap.java
@@ -1,0 +1,36 @@
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+public class InstrumentedMap<K,V> extends ForwardingMap<K,V>{
+	   private int addCount = 0;	
+
+	   public InstrumentedMap(Map<K,V> s){ super(s); }
+	   @Override public V put(K k, V v){ addCount++; return super.put(k,v); }
+	   public int getAddCount(){ return addCount; }
+	}
+
+ class ForwardingMap<K,V> implements Map<K,V> {
+	   private final Map<K,V> s;
+
+	   public ForwardingMap(Map<K,V> s){ this.s = s; }
+	   public           V put(K k, V v)        		{ return s.put(k,v);      }
+	   public           V remove(Object k)			{ return s.remove(k);   }
+	   public 			boolean equals(Object o)	{ return s.equals(o);  }
+	   
+	   public 			int hashCode()      		{ return s.hashCode(); }
+	   public 			String  toString()      	{ return s.toString(); }
+	  
+	   public 			void clear() {s.clear();}
+	   public   		boolean isEmpty()			{ return s.isEmpty();   }
+	   public   		int size() 					{ return s.size();      }
+
+	   public void putAll(Map<? extends K,? extends V> m) 
+	   											{  s.putAll(m);   }
+	   public boolean containsKey(Object key)		 {return s.containsKey(key);}
+	   public boolean containsValue(Object value)    {return s.containsValue(value);}
+	   public V get(Object key) 					 {return s.get(key);}
+	   public Set<K> keySet()						 {return s.keySet();}
+	   public Collection<V> values() 				 {return s.values();}
+	   public Set<Entry<K, V>> entrySet() 			 {return s.entrySet();}
+}

--- a/hw11/src/InstrumentedMap.java
+++ b/hw11/src/InstrumentedMap.java
@@ -14,15 +14,15 @@ public class InstrumentedMap<K,V> extends ForwardingMap<K,V>{
 	   private final Map<K,V> s;
 
 	   public ForwardingMap(Map<K,V> s) { this.s = s; }
-	   public V put(K k, V v)        	{ return s.put(k,v); }
-	   public V remove(Object k)		{ return s.remove(k);}
+	   public V put(K k, V v)           { return s.put(k,v); }
+	   public V remove(Object k)        { return s.remove(k);}
 	   public boolean equals(Object o)  { return s.equals(o);}
-	   public int hashCode()      		{ return s.hashCode();}
-	   public String  toString()      	{ return s.toString();}
+	   public int hashCode()            { return s.hashCode();}
+	   public String  toString()        { return s.toString();}
 	  
 	   public void clear()              {s.clear();}
-	   public boolean isEmpty()			{ return s.isEmpty();}
-	   public int size() 				{ return s.size();}
+	   public boolean isEmpty()         {return s.isEmpty();}
+	   public int size()                {return s.size();}
 
 	   public void putAll(Map<? extends K,? extends V> m) 
 	   	                               { s.putAll(m);}

--- a/hw11/src/InstrumentedMap.java
+++ b/hw11/src/InstrumentedMap.java
@@ -13,24 +13,23 @@ public class InstrumentedMap<K,V> extends ForwardingMap<K,V>{
  class ForwardingMap<K,V> implements Map<K,V> {
 	   private final Map<K,V> s;
 
-	   public ForwardingMap(Map<K,V> s){ this.s = s; }
-	   public           V put(K k, V v)        		{ return s.put(k,v);      }
-	   public           V remove(Object k)			{ return s.remove(k);   }
-	   public 			boolean equals(Object o)	{ return s.equals(o);  }
-	   
-	   public 			int hashCode()      		{ return s.hashCode(); }
-	   public 			String  toString()      	{ return s.toString(); }
+	   public ForwardingMap(Map<K,V> s) { this.s = s; }
+	   public V put(K k, V v)        	{ return s.put(k,v); }
+	   public V remove(Object k)		{ return s.remove(k);}
+	   public boolean equals(Object o)  { return s.equals(o);}
+	   public int hashCode()      		{ return s.hashCode();}
+	   public String  toString()      	{ return s.toString();}
 	  
-	   public 			void clear() {s.clear();}
-	   public   		boolean isEmpty()			{ return s.isEmpty();   }
-	   public   		int size() 					{ return s.size();      }
+	   public void clear() {s.clear();}
+	   public boolean isEmpty()			{ return s.isEmpty();}
+	   public int size() 				{ return s.size();}
 
 	   public void putAll(Map<? extends K,? extends V> m) 
-	   											{  s.putAll(m);   }
-	   public boolean containsKey(Object key)		 {return s.containsKey(key);}
+	   	                               { s.putAll(m);}
+	   public boolean containsKey(Object key)	     {return s.containsKey(key);}
 	   public boolean containsValue(Object value)    {return s.containsValue(value);}
-	   public V get(Object key) 					 {return s.get(key);}
-	   public Set<K> keySet()						 {return s.keySet();}
-	   public Collection<V> values() 				 {return s.values();}
-	   public Set<Entry<K, V>> entrySet() 			 {return s.entrySet();}
+	   public V get(Object key)                      {return s.get(key);}
+	   public Set<K> keySet()	                     {return s.keySet();}
+	   public Collection<V> values()                 {return s.values();}
+	   public Set<Entry<K, V>> entrySet()            {return s.entrySet();}
 }

--- a/hw11/src/InstrumentedSet.java
+++ b/hw11/src/InstrumentedSet.java
@@ -1,0 +1,26 @@
+import java.util.Set;
+import java.util.Collection;
+
+public class InstrumentedSet<E> extends ForwardingSet<E> {
+    private int addCount = 0;
+
+    public InstrumentedSet(Set<E> s) {
+        super(s);
+    }
+
+    @Override
+    public boolean add(E e) {
+        addCount++;
+        return super.add(e);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        addCount += c.size();
+        return super.addAll(c);
+    }
+
+    public int getAddCount() {
+        return addCount;
+    }
+}

--- a/hw11/src/InstrumentedTest.java
+++ b/hw11/src/InstrumentedTest.java
@@ -2,8 +2,13 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Before;
 
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.HashSet;
 
 public class InstrumentedTest {
@@ -34,6 +39,49 @@ public class InstrumentedTest {
         // symmetry
         assertFalse(h.equals(t));
         assertFalse(t.equals(h));
+    }
+
+
+    InstrumentedList<String> a;
+    InstrumentedList<String> b;
+    InstrumentedList<String> c;
+
+    @Before
+    public void init2() {
+        a = new InstrumentedList<String>(new ArrayList<>());
+        b = new InstrumentedList<String>(new LinkedList<>());
+        c = new InstrumentedList<String>(new ArrayList<>());
+
+        a.add("Dog");
+        a.add("Cat");
+
+        b.add("Dog");
+        b.add("Cat");
+
+        c.add("Dog");
+        c.add("Cat");
+    }
+
+    @Test
+    public void testListEqualsReflexive() {
+        //reflexive
+        assertTrue(a.equals(a));
+
+    }
+
+    @Test
+    public void testListEqualsSymmetric() {
+        // symmetry
+        assertTrue(a.equals(b));
+        assertTrue(b.equals(a));
+    }
+
+    @Test
+    public void testListEqualsTransitive() {
+        // transitivity
+        assertTrue(a.equals(b));
+        assertTrue(b.equals(c));
+        assertTrue(a.equals(c));
     }
 
 }

--- a/hw11/src/InstrumentedTest.java
+++ b/hw11/src/InstrumentedTest.java
@@ -2,31 +2,38 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import org.junit.Before;
 
 import java.util.HashSet;
 
 public class InstrumentedTest {
+    InstrumentedCollection<String> h;
+    InstrumentedCollection<String> t;
 
-	@Test
-	public void testEquals() {
-		InstrumentedCollection<String> h = new InstrumentedCollection<>(new HashSet<>());
-        InstrumentedCollection<String> t = new InstrumentedCollection<>(new HashSet<>());
+    @Before
+    public void init() {
+        h = new InstrumentedCollection<>(new HashSet<>());
+        t = new InstrumentedCollection<>(new HashSet<>());
 
         h.add("Dog");
         h.add("Cat");
 
         t.add("Dog");
         t.add("Cat");
+    }
 
-        // fails both
-
+	@Test
+	public void testCollectionEqualsReflexive() {
 		//reflexive
 		assertTrue(h.equals(h));
 
-		// symmetry
-		assertTrue(h.equals(t));
-		assertTrue(t.equals(h));
-
 	}
+
+	@Test
+    public void testCollectionEqualsSymmetric() {
+        // symmetry
+        assertTrue(h.equals(t));
+        assertTrue(t.equals(h));
+    }
 
 }

--- a/hw11/src/InstrumentedTest.java
+++ b/hw11/src/InstrumentedTest.java
@@ -1,7 +1,7 @@
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import org.junit.Before;
 
 import java.util.HashSet;
@@ -25,15 +25,15 @@ public class InstrumentedTest {
 	@Test
 	public void testCollectionEqualsReflexive() {
 		//reflexive
-		assertTrue(h.equals(h));
+		assertFalse(h.equals(h));
 
 	}
 
 	@Test
     public void testCollectionEqualsSymmetric() {
         // symmetry
-        assertTrue(h.equals(t));
-        assertTrue(t.equals(h));
+        assertFalse(h.equals(t));
+        assertFalse(t.equals(h));
     }
 
 }

--- a/hw11/src/InstrumentedTest.java
+++ b/hw11/src/InstrumentedTest.java
@@ -1,0 +1,32 @@
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashSet;
+
+public class InstrumentedTest {
+
+	@Test
+	public void testEquals() {
+		InstrumentedCollection<String> h = new InstrumentedCollection<>(new HashSet<>());
+        InstrumentedCollection<String> t = new InstrumentedCollection<>(new HashSet<>());
+
+        h.add("Dog");
+        h.add("Cat");
+
+        t.add("Dog");
+        t.add("Cat");
+
+        // fails both
+
+		//reflexive
+		assertTrue(h.equals(h));
+
+		// symmetry
+		assertTrue(h.equals(t));
+		assertTrue(t.equals(h));
+
+	}
+
+}

--- a/hw11/src/README.txt
+++ b/hw11/src/README.txt
@@ -5,6 +5,7 @@ InstrumentedCollection object instance. The tests show that equals() fails refle
 symmetry when we replace the Set interface with Collection.
 
 There is no problem with the equals method in the map implementation of
-InstrumentedSet. The equals method in the Map interface calls entrySet() to
-create a Set of itself and the Object, which then calls the Sets equals that
-ends up calling Object's equals method. 
+InstrumentedSet. The equals method in the Map interface calls the objects
+entrySet method as well as its own. This method creates a Set of the mappings
+for each. It then calls equals on those two Sets. It wouldn't matter if the object 
+is a Hashmap or a Treemap, because of the creation of the two Sets.

--- a/hw11/src/README.txt
+++ b/hw11/src/README.txt
@@ -1,3 +1,8 @@
+Using the Collection interface instead of Set makes it such that equals() no longer
+satisfies the contract since, referring to the tests in InstrumentedTest.java, equals()
+compares the Collection s, which is a HashSet, in ForwardingCollection to an
+InstrumentedCollection object instance. The tests show that equals() fails reflexivity and
+symmetry when we replace the Set interface with Collection.
 
 There is no problem with the equals method in the map implementation of
 InstrumentedSet. The equals method in the Map interface calls entrySet() to

--- a/hw11/src/README.txt
+++ b/hw11/src/README.txt
@@ -1,0 +1,5 @@
+
+There is no problem with the equals method in the map implementation of
+InstrumentedSet. The equals method in the Map interface calls entrySet() to
+create a Set of itself and the Object, which then calls the Sets equals that
+ends up calling Object's equals method. 

--- a/hw11/src/README.txt
+++ b/hw11/src/README.txt
@@ -9,3 +9,8 @@ InstrumentedSet. The equals method in the Map interface calls the objects
 entrySet method as well as its own. This method creates a Set of the mappings
 for each. It then calls equals on those two Sets. It wouldn't matter if the object 
 is a Hashmap or a Treemap, because of the creation of the two Sets.
+
+There is no problem with the equals method in the list implementation. The equals method in the List interface
+calls the object's equals method. The List interface method defines two lists to be equal
+if they contain the same elements in the same order. It doesn't matter if the two lists being compared have
+different implementations, as long as they implement the List interface.


### PR DESCRIPTION
## Assignment
**Goal**: Favoring composition over inheritance. Bloch, Item 16. 
Consider the InstrumentedSet example from Bloch Item 16 (as well as in-class exercise #10A).

1. Replace sets with collections. equals() no longer satisfies its contract.
- Explain why there is a problem.
- Demonstrate the problem with a suitable JUnit test.
2. Now consider the example:
- With lists.
- With maps.
In either case, is there a problem with equals()? If so, give a JUnit test. If not, why not? If you're not sure, simply run the code.

The GTA will look for correct responses, appropriate JUnit tests, and plausible explanations when doing the grading.

## Tasks

- [x] replace sets with collections and provide JUnit test to demonstrate problem

- [ ] use lists instead. is there prob with equals()? If so, give JUnit test. If not, why not?

- [ ] use maps instead. is there prob with equals()? If so, give JUnit test. If not, why not?

- [ ] Have readme with our answers to some of the questions that can't be adequately answered via code, tests, or comments in code